### PR TITLE
Aircraft schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geps/geofs-types",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@geps/geofs-types",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/jquery": "3.5.14",
@@ -21,6 +21,7 @@
         "eslint-config-prettier": "~8.5.0",
         "husky": "~7.0.4",
         "prettier": "~2.6.0",
+        "typedoc": "^0.22.13",
         "typescript": "~4.6.2"
       }
     },
@@ -1245,6 +1246,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -1274,6 +1281,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
+    "node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/merge2": {
@@ -1572,6 +1597,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -1680,6 +1716,49 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.22.13",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.13.tgz",
+      "integrity": "sha512-NHNI7Dr6JHa/I3+c62gdRNXBIyX7P33O9TafGLd07ur3MqzcKgwTvpg18EtvCLHJyfeSthAtCLpM7WkStUmDuQ==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.2.0",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.12",
+        "minimatch": "^5.0.1",
+        "shiki": "^0.10.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 12.10.0"
+      },
+      "peerDependencies": {
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/typescript": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
@@ -1764,6 +1843,18 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -2667,6 +2758,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2691,6 +2788,18 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
+    "marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1",
@@ -2884,6 +2993,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2959,6 +3079,39 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
+    "typedoc": {
+      "version": "0.22.13",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.13.tgz",
+      "integrity": "sha512-NHNI7Dr6JHa/I3+c62gdRNXBIyX7P33O9TafGLd07ur3MqzcKgwTvpg18EtvCLHJyfeSthAtCLpM7WkStUmDuQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.2.0",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.12",
+        "minimatch": "^5.0.1",
+        "shiki": "^0.10.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "typescript": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
@@ -3020,6 +3173,18 @@
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^3.0.0"
       }
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-config-prettier": "~8.5.0",
     "husky": "~7.0.4",
     "prettier": "~2.6.0",
+    "typedoc": "^0.22.13",
     "typescript": "~4.6.2"
   }
 }

--- a/schema/aircraft.schema.json
+++ b/schema/aircraft.schema.json
@@ -14,6 +14,1001 @@
         }
       }
     },
+    "Filters": {
+      "description": "Animation filters",
+      "type": "object",
+      "properties": {
+        "ratio": {
+          "description": "A multiplier for the value.",
+          "type": "number"
+        },
+        "threshold": {
+          "description": "Value is converted to boolean when smaller than threshold",
+          "type": "number"
+        },
+        "between": {
+          "description": "Value is converted to boolean when between values",
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "delay": {
+          "description": "Add or subtract and clamp value between (0 - 1)",
+          "type": "number"
+        },
+        "eq": {
+          "description": "Equal to value (==)",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "notEq": {
+          "description": "Not equal to value (!=)",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "noteq": {
+          "description": "Not equal to value (!=)",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "gt": {
+          "description": "Greater than value (>)",
+          "type": "number"
+        },
+        "lt": {
+          "description": "Less than value (<)",
+          "type": "number"
+        },
+        "min": {
+          "description": "Returns the value if it is larger than min. If not, returns min.",
+          "type": "number"
+        },
+        "max": {
+          "description": "Returns the value if it is smaller than max. If not, returns max.",
+          "type": "number"
+        },
+        "when": {
+          "description": "Returns true if the value is in the array; otherwise, false.",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "whenNot": {
+          "description": "Returns true if the value is not in the array; otherwise, false."
+        },
+        "offset": {
+          "description": "Add offset after applying \"ratio\"",
+          "type": "number"
+        },
+        "power": {
+          "description": "Raise value to provided power",
+          "type": "number"
+        },
+        "valueRamp": {
+          "description": "Specify a ramp of values to replace the original animation value.\nNew values are looked-up in the array depending on original value varying from 0 to 1.",
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "ramp": {
+          "description": "Array of 2 or 4 stop values to generate an increasing--level--decreasing ramp from 0 to 1 (eventually back to 0) - mostly used for sound.",
+          "type": "array",
+          "oneOf": [
+            {
+              "minItems": 2,
+              "maxItems": 2
+            },
+            {
+              "minItems": 4,
+              "maxItems": 4
+            }
+          ]
+        },
+        "ratioRamp": {
+          "description": "Specify a ramp of ratios by which to multiply the value.\nRatios are looked-up in the array depending on value varying from 0 to 1.",
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "fmin": {
+          "description": "Returns the value if it is larger than min. If not, returns min.",
+          "type": "number"
+        },
+        "fmax": {
+          "description": "Returns the value if it is smaller than max. If not, returns max.",
+          "type": "number"
+        },
+        "negthreshold": {
+          "description": "Value is converted to boolean when greater than threshold",
+          "type": "number"
+        },
+        "preoffset": {
+          "description": "Add offset before applying \"ratio\"",
+          "type": "number"
+        },
+        "set": {
+          "type": "number"
+        },
+        "abs": {
+          "description": "When set to `true`, use the absolute value of the value.",
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1
+            }
+          ]
+        }
+      }
+    },
+    "AnimationBase": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Base"
+        },
+        {
+          "$ref": "#/definitions/Filters"
+        }
+      ],
+      "properties": {
+        "frame": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "description": "enginesOn: Boolean: 1 if engine is on, 0 if not.\nprop: Prop rotation [0, 360].\nthrust: In Newton.rpm, throttle: [0, 1]\npitch: Control input [0, 1]\nroll: Control input [0, 1]\nyaw: Control input [0, 1]\nbrakes: Boolean: 1 if brakes are on, 0 if not.\ngearPosition: Current gear position [0, 1]\ngearTarget: Reaching gear position [0, 1]\nflapsValue: Current flaps position as [0, 1]\nflapsPosition: Current flaps position in steps [0, flapsSteps]\nflapsTarget: Reaching flaps position in steps [0, flapsSteps]\nairbrakesPosition: Current airbrakes position as [0, 1]\nairbrakesTarget: Reaching airbrakes position as [0, 1]\ngroundContact: Boolean: 1 if aircraft is in contact with ground, 0 if not.\nrollingSpeed: Aircraft speed in m/s when rolling on ground.\nmaxAngularVRatio: Rolling wheel angular speed.\nkias: Indicated airspeed in knots.\ntas: True airspeed in knots.\nmach: Airspeed as Mach number.\naltitude: In feet.\ntenFeet: Altitude in tens of feet.\nhundredFeet: Altitude in hundreds of feet.\nthousandFeet: Altitude in thousands of feet.\nclimbrate: Climb rate in feet per minute.\nheading: The aircraft's heading in degrees [-180, 180].\nheading360: The aircraft's heading in degrees [0, 360].\natilt: The aircraft's tilt in degrees.\naroll: The aircraft's roll in degrees.\nrelativeWind: In degrees, from aircraft forward.\nwindSpeed: Wind speed in meters per second.\nview: camera mode name [\"follow\", \"cockpit\", \"cockpitless\", \"chase\", \"free\"].\nstrobe: Boolean, set to 1 every 1400ms, for 100ms duration.\nstrobe2: Boolean set to 1 every 1700ms, for 100ms duration.\nrandom: Returns a random value [0, 1).",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "",
+                    "enginesOn",
+                    "prop",
+                    "thrust",
+                    "rpm",
+                    "throttle",
+                    "pitch",
+                    "roll",
+                    "yaw",
+                    "brakes",
+                    "gearPosition",
+                    "gearTarget",
+                    "flapsValue",
+                    "flapsPosition",
+                    "flapsTarget",
+                    "airbrakesPosition",
+                    "airbrakesTarget",
+                    "groundContact",
+                    "rollingSpeed",
+                    "maxAngularVRatio",
+                    "kias",
+                    "tas",
+                    "mach",
+                    "altitude",
+                    "tenFeet",
+                    "hundredFeet",
+                    "thousandFeet",
+                    "climbrate",
+                    "heading",
+                    "heading360",
+                    "atilt",
+                    "aroll",
+                    "relativeWind",
+                    "windSpeed",
+                    "view",
+                    "random",
+                    "parkingBrake",
+                    "stalls",
+                    "aoa",
+                    "altThousands",
+                    "climbrateABS",
+                    "climbrateLog",
+                    "night",
+                    "optionalAnimatedPartPosition",
+                    "cameraMode",
+                    "hours",
+                    "minutes",
+                    "invGearPosition",
+                    "altTensShift",
+                    "altTens",
+                    "altTenThousands",
+                    "machUnits",
+                    "machTens",
+                    "machTenth",
+                    "machHundredth",
+                    "arrestingHookTension",
+                    "accX",
+                    "accY",
+                    "accZ",
+                    "trim",
+                    "rawPitch",
+                    "rawpitch",
+                    "rawYaw",
+                    "envelopeTemp",
+                    "function()",
+                    "ktas",
+                    "gearTraget",
+                    "turnrate"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "pattern": "^strobe[23]?$"
+                },
+                {
+                  "type": "string",
+                  "pattern": "^.*(Rotation|Suspension)$"
+                }
+              ]
+            }
+          },
+          "required": ["value"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "function": {
+              "description": "A function to run. Must return a value that will be used as the animation value.",
+              "type": "string",
+              "pattern": "^{(.|\n)*return\\ ?(.|\n)+}$"
+            }
+          },
+          "required": ["function"]
+        }
+      ]
+    },
+    "Animation": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AnimationBase"
+        }
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "rotate",
+            "scale",
+            "translate",
+            "show",
+            "hide",
+            "sound",
+            "property",
+            "justhide",
+            "justshow",
+            "translateX",
+            "translateY",
+            "scaleX",
+            "scaleY",
+            "moveX",
+            "moveY",
+            "throttle",
+            "pitch",
+            "strobe"
+          ]
+        },
+        "axis": {
+          "description": "\"X\", \"Y\", \"Z\" for rotation, vector for translation",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["X", "Y", "Z"]
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        }
+      },
+      "required": ["type"]
+    },
+    "PartBase": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Base"
+        }
+      ],
+      "properties": {
+        "name": {
+          "description": "Part's name/id.",
+          "type": "string"
+        },
+        "parent": {
+          "description": "Parent's name.",
+          "type": "string"
+        },
+        "model": {
+          "description": "Name of the DAE model declared in KML.",
+          "type": "string"
+        },
+        "node": {
+          "description": "Name of the node in the root model.\n! A \"root\" part must be declared to load the main GLTF file.",
+          "type": "string"
+        },
+        "position": {
+          "description": "Relative to the parent (or root).",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 3,
+              "maxItems": 3
+            }
+          ]
+        },
+        "rotaition": {
+          "description": "Relative to the parent (or root).",
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "rotation": {
+          "description": "Relative to the parent (or root).",
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "scale": {
+          "description": "Relative to the parent (or root).",
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "forceDirection": {
+          "description": "The direction in which the force (lift, thrust) will be applied.",
+          "type": "string",
+          "enum": ["X", "Y", "Z"]
+        },
+        "points": {
+          "type": "object",
+          "properties": {
+            "forceSourcePoint": {
+              "type": "array",
+              "items": {
+                "description": "The source of force vector relative to the part origin",
+                "type": "number",
+                "minItems": 3,
+                "maxItems": 3
+              }
+            }
+          },
+          "required": ["forceSourcePoint"],
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "minItems": 3,
+              "maxItems": 3
+            }
+          }
+        },
+        "collisionPoints": {
+          "description": "Specify where, on the model, collisions with the ground should occur - best used on the \"body\" part of the aircraft (type=frame).",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "minItems": 3,
+              "maxItems": 3
+            }
+          }
+        },
+        "animations": {
+          "description": "Array of animations to be applied.",
+          "oneOf": [
+            {
+              "type": "string",
+              "const": ""
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Animation"
+              }
+            }
+          ]
+        },
+        "light": {
+          "type": "string",
+          "enum": ["white", "red", "green", ""]
+        },
+        "textures": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "index": {
+                "type": "number"
+              },
+              "filename": {
+                "type": "string"
+              }
+            },
+            "required": ["index", "filename"]
+          }
+        },
+        "buoyancy": {
+          "type": "number"
+        },
+        "noCastShadows": {
+          "type": "boolean"
+        },
+        "noReceiveShadows": {
+          "type": "boolean"
+        },
+        "propwash": {
+          "type": "number"
+        },
+        "include": {
+          "type": "string"
+        },
+        "indices": {
+          "type": "number"
+        },
+        "liftFactor": {
+          "type": "number"
+        },
+        "dragFactor": {
+          "type": "number"
+        },
+        "initialTemperature": {
+          "type": "number"
+        },
+        "volume": {
+          "type": "number"
+        },
+        "heatingSpeed": {
+          "type": "number"
+        },
+        "coolingSpeed": {
+          "type": "number"
+        },
+        "controller": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "const": "pitch"
+            },
+            "recenter": {
+              "type": "boolean"
+            },
+            "sensitivity": {
+              "type": "number"
+            },
+            "ratio": {
+              "type": "number"
+            }
+          },
+          "required": ["name", "ratio"]
+        },
+        "area": {
+          "type": "number"
+        },
+        "doNotScalePosition": {
+          "type": "boolean"
+        }
+      },
+      "required": ["name"]
+    },
+    "Part": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PartBase"
+        }
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "not": {
+            "enum": ["airfoil", "engine", "wheel", "pad", "hook"]
+          }
+        }
+      }
+    },
+    "AirfoilPart": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PartBase"
+        }
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "airfoil"
+        },
+        "stalls": {
+          "description": "Specify if an airfoil is subject to stall.",
+          "type": "boolean"
+        },
+        "stallIncidence": {
+          "description": "Angle of Attack (AoA) in deg. at which stall occurs.",
+          "type": "number"
+        },
+        "zeroLiftIncidence": {
+          "description": "Angle of Attack (AoA) at which, lift equals 0 - lift decreases linearly from stallIncidence",
+          "type": "number"
+        },
+        "span": {
+          "type": "number"
+        },
+        "chord": {
+          "type": "number"
+        },
+        "efficiencyFactor": {
+          "type": "number"
+        },
+        "aspectRatio": {
+          "type": "number"
+        }
+      },
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "liftFactor": {
+              "description": "An arbitrary lift coefficient for airfoils (not used if \"area\" is specified).",
+              "type": "number"
+            },
+            "dragFactor": {
+              "description": "An arbitrary drag coefficient for airfoils (not used if \"area\" is specified).",
+              "type": "number"
+            }
+          },
+          "required": ["liftFactor", "dragFactor"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "area": {
+              "description": "The airfoil surface area - lift and drag will be computed from this.",
+              "type": "number"
+            }
+          },
+          "required": ["area"]
+        }
+      ],
+      "required": ["type"]
+    },
+    "EnginePart": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PartBase"
+        }
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "engine"
+        },
+        "thrust": {
+          "description": "In Newton.",
+          "type": "number"
+        },
+        "afterBurnerThrust": {
+          "description": "In Newton.",
+          "type": "number"
+        },
+        "reverseThrust": {
+          "description": "In Newton.",
+          "type": "number"
+        },
+        "contrail": {
+          "description": "Does the engine generate contrail",
+          "type": "boolean"
+        }
+      },
+      "required": ["type", "thrust"]
+    },
+    "WheelPart": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PartBase"
+        }
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["wheel", "pad"]
+        },
+        "suspension": {
+          "type": "object",
+          "properties": {
+            "motion": {
+              "type": "string",
+              "enum": ["rotation", "translate"]
+            },
+            "axis": {
+              "type": "string",
+              "enum": ["X", "Y", "Z"]
+            },
+            "ratio": {
+              "type": "number"
+            },
+            "stiffness": {
+              "type": "number"
+            },
+            "damping": {
+              "type": "number"
+            },
+            "restLength": {
+              "type": "number"
+            },
+            "hardPoint": {
+              "type": "number"
+            }
+          },
+          "required": ["stiffness", "damping"]
+        },
+        "contactType": {
+          "type": "string"
+        }
+      },
+      "required": ["type", "suspension"]
+    },
+    "HookPart": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PartBase"
+        }
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "hook"
+        },
+        "hook": {
+          "type": "object",
+          "properties": {
+            "strength": {
+              "type": "number"
+            }
+          },
+          "required": ["strength"]
+        }
+      },
+      "required": ["type", "hook"]
+    },
+    "BaseContactProperty": {
+      "type": "object",
+      "properties": {
+        "frictionCoef": {
+          "description": "Static friction coefficient - when not slipping.",
+          "type": "number"
+        },
+        "dynamicFriction": {
+          "description": "Dynamic friction coefficient - during slip.",
+          "type": "number"
+        },
+        "damping": {
+          "description": "A damping factor to try and hide jerkiness of collisions in some cases.",
+          "type": "number"
+        }
+      },
+      "required": ["frictionCoef", "dynamicFriction", "damping"]
+    },
+    "Instrument": {
+      "allOf": [{ "$ref": "#/definitions/Base" }],
+      "type": "object",
+      "properties": {
+        "animations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Animation"
+          }
+        },
+        "cockpit": {
+          "type": "object",
+          "properties": {
+            "position": {
+              "description": "In cockpit position relative to origin",
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 3,
+              "maxItems": 3
+            },
+            "scale": {
+              "type": "number"
+            }
+          },
+          "required": ["position", "scale"]
+        },
+        "overlay": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string"
+            },
+            "size": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "oneOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "y": {
+                  "oneOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": ["x", "y"]
+            },
+            "anchor": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": "number"
+                },
+                "y": {
+                  "type": "number"
+                }
+              },
+              "required": ["x", "y"]
+            },
+            "position": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": "number"
+                },
+                "y": {
+                  "type": "number"
+                }
+              },
+              "required": ["x", "y"]
+            },
+            "offset": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": "number"
+                },
+                "y": {
+                  "type": "number"
+                }
+              },
+              "required": ["x", "y"]
+            },
+            "iconFrame": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": "number"
+                },
+                "y": {
+                  "type": "number"
+                }
+              },
+              "required": ["x", "y"]
+            },
+            "drawOrder": {
+              "type": "number"
+            },
+            "rescale": {
+              "type": "boolean"
+            },
+            "rescalePosition": {
+              "type": "boolean"
+            },
+            "overlays": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Instrument/properties/overlay"
+              }
+            },
+            "animations": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Animation"
+              }
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": ["url", "size", "anchor", "position"]
+        },
+        "center": {
+          "type": "boolean"
+        },
+        "stackX": {
+          "type": "boolean"
+        }
+      }
+    },
+    "Sound": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Base"
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Sound id.",
+          "type": "string"
+        },
+        "file": {
+          "description": "URL to the mp3 file.",
+          "type": "string"
+        },
+        "effects": {
+          "description": "Sound effects",
+          "type": "object",
+          "properties": {
+            "volume": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AnimationBase"
+                }
+              ],
+              "properties": {
+                "duration": {
+                  "type": "number"
+                }
+              }
+            },
+            "pitch": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AnimationBase"
+                }
+              ],
+              "properties": {
+                "duration": {
+                  "type": "number"
+                }
+              }
+            },
+            "start": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AnimationBase"
+                }
+              ],
+              "properties": {
+                "duration": {
+                  "type": "number"
+                }
+              }
+            },
+            "stop": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AnimationBase"
+                }
+              ],
+              "properties": {
+                "duration": {
+                  "type": "number"
+                }
+              }
+            },
+            "play": {
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/AnimationBase"
+                }
+              ],
+              "properties": {
+                "duration": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "fadeDuration": {
+          "description": "duration of fade-in/fade-out in ms",
+          "type": "number"
+        },
+        "cut": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "lowLatency": {
+          "type": "boolean"
+        },
+        "loop": {
+          "type": "boolean"
+        },
+        "retard": {
+          "type": "number"
+        }
+      },
+      "required": ["id", "file"]
+    },
     "PluginsDefinitions": {
       "type": "object",
       "properties": {
@@ -112,7 +1107,7 @@
         },
         "flapsTravelTime": {
           "description": "Seconds per degrees.",
-          "anyOf": [
+          "oneOf": [
             {
               "type": "number"
             },
@@ -123,7 +1118,7 @@
         },
         "flapsSteps": {
           "description": "Number of positions for the flaps",
-          "anyOf": [
+          "oneOf": [
             {
               "type": "number"
             },
@@ -189,7 +1184,7 @@
         },
         "autopilot": {
           "description": "When set to true, enable the default autopilot.\nWhen set to an object, enable an autopilot with custom PID controls. All configuration is optional.\nLeave empty to disbale the autopilot (same as false).",
-          "anyOf": [
+          "oneOf": [
             {
               "type": "boolean"
             },
@@ -284,8 +1279,22 @@
           "type": "array",
           "minItems": 1,
           "items": {
-            "anyOf": [
-              // TODO this
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Part"
+              },
+              {
+                "$ref": "#/definitions/AirfoilPart"
+              },
+              {
+                "$ref": "#/definitions/EnginePart"
+              },
+              {
+                "$ref": "#/definitions/WheelPart"
+              },
+              {
+                "$ref": "#/definitions/HookPart"
+              }
             ]
           }
         },
@@ -296,7 +1305,7 @@
             "wheel": {
               "allOf": [
                 {
-                  "$ref": "" //TODO BaseContactProperty
+                  "$ref": "#/definitions/BaseContactProperty"
                 }
               ],
               "type": "object",
@@ -313,16 +1322,16 @@
             }
           },
           "additionalProperties": {
-            "$ref": "" //TODO
+            "$ref": "#/definitions/BaseContactProperty"
           }
         },
         "instruments": {
           "type": "object",
           "properties": {
             "airspeed": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -335,9 +1344,9 @@
               ]
             },
             "airspeedJet": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -350,9 +1359,9 @@
               ]
             },
             "airspeedSupersonic": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -365,9 +1374,9 @@
               ]
             },
             "altitude": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -380,9 +1389,9 @@
               ]
             },
             "attitude": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -395,9 +1404,9 @@
               ]
             },
             "attitudeJet": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -410,9 +1419,9 @@
               ]
             },
             "vario": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -425,9 +1434,9 @@
               ]
             },
             "varioJet": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -440,9 +1449,9 @@
               ]
             },
             "compass": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -455,9 +1464,9 @@
               ]
             },
             "rpm": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -470,9 +1479,9 @@
               ]
             },
             "rpmJet": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -485,9 +1494,9 @@
               ]
             },
             "spoilers": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -500,9 +1509,9 @@
               ]
             },
             "brakes": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -515,9 +1524,9 @@
               ]
             },
             "gear": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -530,9 +1539,9 @@
               ]
             },
             "flaps": {
-              "anyOf": [
+              "oneOf": [
                 {
-                  "$ref": "" //TODO Instrument
+                  "$ref": "#/definitions/Instrument"
                 },
                 {
                   "type": "string",
@@ -546,7 +1555,7 @@
             }
           },
           "additionalProperties": {
-            "$ref": "" //TODO Instrument
+            "$ref": "#/definitions/Instrument"
           }
         },
         "soundSet": {
@@ -558,7 +1567,7 @@
           "description": "\"startup\" and \"shutdown\" sound ids are hardcoded.",
           "type": "array",
           "items": {
-            "$ref": "" //TODO Sound
+            "$ref": "#/definitions/Sound"
           }
         },
         "cameras": {

--- a/schema/aircraft.schema.json
+++ b/schema/aircraft.schema.json
@@ -1,0 +1,642 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$title": "Aircraft",
+  "$description": "A GeoFS aircraft definition",
+  "type": "array",
+  "minItems": 1,
+  "maxItems": 1,
+  "definitions": {
+    "Base": {
+      "type": "object",
+      "properties": {
+        "comment": {
+          "type": "string"
+        }
+      }
+    },
+    "PluginsDefinitions": {
+      "type": "object",
+      "properties": {
+        "fmc": {
+          "type": "object",
+          "properties": {
+            "climb": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            },
+            "descent": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "required": ["climb", "descent"]
+        },
+        "nosewheel": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "platform": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "maxLimits": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "type": {
+          "type": "string"
+        },
+        "typeIndex": {
+          "type": "string"
+        }
+      }
+    },
+    "Definition": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Base"
+        }
+      ],
+      "properties": {
+        "mass": {
+          "type": "number",
+          "description": "Total mass in kg.",
+          "minimum": 0
+        },
+        "tensorFactor": {
+          "description": "Tweak the rotation inertia",
+          "type": "number"
+        },
+        "dragFactor": {
+          "description": "A global drag coefficient",
+          "type": "number"
+        },
+        "com": {
+          "description": "To move the center of mass of the aircraft",
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "COM": {
+          "description": "To move the center of mass of the aircraft",
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3
+        },
+        "gearTravelTime": {
+          "description": "In seconds",
+          "type": "number"
+        },
+        "flapsTravelTime": {
+          "description": "Seconds per degrees.",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flapsSteps": {
+          "description": "Number of positions for the flaps",
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "flapsPositions": {
+          "description": "Positions in degrees for each flap step",
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        },
+        "airbrakesTravelTime": {
+          "description": "In seconds.",
+          "type": "number"
+        },
+        "reverse": {
+          "description": "Are thrust reversers available.",
+          "type": "boolean"
+        },
+        "zeroThrustAltitude": {
+          "description": "The altitude in feet at which the engine does not produce any thrust (linear from sea level).",
+          "type": "number"
+        },
+        "minRPM": {
+          "description": "Minimum RPM of the engine",
+          "type": "number"
+        },
+        "maxRPM": {
+          "description": "Maximum RPM of the engine",
+          "type": "number"
+        },
+        "driveRatio": {
+          "description": "Affect the spinning of propellers",
+          "type": "number"
+        },
+        "engineInertia": {
+          "description": "Ratio to affect the time it takes for the engine to reach a certain RPM value.",
+          "type": "number"
+        },
+        "startupTime": {
+          "description": "In seconds - to match the startup sound.",
+          "type": "number"
+        },
+        "startAltitude": {
+          "description": "Compensate for landing gear height at initialization (when on ground)",
+          "type": "number"
+        },
+        "startTilt": {
+          "description": "Initial tilt angle (when on ground).",
+          "type": "number"
+        },
+        "minimumSpeed": {
+          "description": "Initial speed when in the air, in knots.",
+          "type": "number"
+        },
+        "motionSensitivity": {
+          "description": "Ratio of head (camera) motion due to acceleration.",
+          "type": "number"
+        },
+        "autopilot": {
+          "description": "When set to true, enable the default autopilot.\nWhen set to an object, enable an autopilot with custom PID controls. All configuration is optional.\nLeave empty to disbale the autopilot (same as false).",
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": ["true", "false"]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "pitchAnglePID": {
+                  "description": "Controller for aircraft pitch angle based on altitude target",
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 3,
+                  "maxItems": 3
+                },
+                "elevatorPitchPID": {
+                  "description": "Controller for elevator deflection based on pitchAnglePID output.",
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 3,
+                  "maxItems": 3
+                },
+                "bankAnglePID": {
+                  "description": "Controller for bank angle based on heading target.",
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 3,
+                  "maxItems": 3
+                },
+                "aileronsRollPID": {
+                  "description": "Controller for ailerons deflection based on bankAnglePID output.",
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 3,
+                  "maxItems": 3
+                },
+                "throttlePID": {
+                  "description": "Controller for throttle based on speed target.",
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  },
+                  "minItems": 3,
+                  "maxItems": 3
+                },
+                "effectivenessRatioMaximum": {
+                  "description": "Maximum speed related deflection divider",
+                  "default": 1.5,
+                  "type": "number"
+                },
+                "baseClimbrate": {
+                  "description": "Climb rate before speed related multiplier.",
+                  "type": "number",
+                  "default": 500
+                },
+                "baseDescentrate": {
+                  "description": "Descent rate before speed related multiplier",
+                  "type": "number",
+                  "default": -500
+                },
+                "maxPitchAngle": {
+                  "type": "number",
+                  "default": 20
+                },
+                "minPitchAngle": {
+                  "type": "number",
+                  "default": -20
+                },
+                "maxBankAngle": {
+                  "type": "number",
+                  "default": 50
+                },
+                "yawBankAngleRatio": {
+                  "type": "number"
+                }
+              }
+            }
+          ]
+        },
+        "parts": {
+          "description": "Part defined for the aircraft can be associated to a 3D model a node in the model or simply have a functional role (airfoil, engine, etc.).\nApplicable properties vary with part's type (frame, airfoil, engine, wheel).",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "anyOf": [
+              // TODO this
+            ]
+          }
+        },
+        "contactProperties": {
+          "description": "Contact properties must be specified for part types that declares collisionPoints.",
+          "type": "object",
+          "properties": {
+            "wheel": {
+              "allOf": [
+                {
+                  "$ref": "" //TODO BaseContactProperty
+                }
+              ],
+              "type": "object",
+              "properties": {
+                "rollingFriction": {
+                  "type": "number"
+                },
+                "lockSpeed": {
+                  "description": "arbitrary minimum speed at which the wheel lock (static rest)",
+                  "type": "number"
+                }
+              },
+              "required": ["rollingFriction"]
+            }
+          },
+          "additionalProperties": {
+            "$ref": "" //TODO
+          }
+        },
+        "instruments": {
+          "type": "object",
+          "properties": {
+            "airspeed": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "airspeedJet": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "airspeedSupersonic": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "altitude": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "attitude": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "attitudeJet": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "vario": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "varioJet": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "compass": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "rpm": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "rpmJet": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "spoilers": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "brakes": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "gear": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            },
+            "flaps": {
+              "anyOf": [
+                {
+                  "$ref": "" //TODO Instrument
+                },
+                {
+                  "type": "string",
+                  "const": ""
+                },
+                {
+                  "type": "string",
+                  "minLength": 1
+                }
+              ]
+            }
+          },
+          "additionalProperties": {
+            "$ref": "" //TODO Instrument
+          }
+        },
+        "soundSet": {
+          "description": "For legacy reasons.",
+          "type": "string",
+          "const": "player"
+        },
+        "sounds": {
+          "description": "\"startup\" and \"shutdown\" sound ids are hardcoded.",
+          "type": "array",
+          "items": {
+            "$ref": "" //TODO Sound
+          }
+        },
+        "cameras": {
+          "type": "object",
+          "properties": {
+            "follow": {},
+            "cockpit": {}
+          },
+          "additionalProperties": {}
+        },
+        "cockpitShadowMapMaxDistance": {
+          "type": "number"
+        },
+        "zeroRPMAltitude": {
+          "type": "number"
+        },
+        "shutdownTime": {
+          "type": "number"
+        },
+        "cockpitModel": {
+          "type": "boolean"
+        },
+        "shadowBox": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": "number"
+          }
+        },
+        "optionalAnimatedPartTravelTime": {
+          "type": "number"
+        },
+        "cockpitScaleFix": {
+          "type": "number"
+        },
+        "shadowFile": {
+          "type": "string"
+        },
+        "shadowURL": {
+          "type": "string"
+        },
+        "dragCoefficient": {
+          "type": "number"
+        },
+        "brakeDamping": {
+          "type": "number"
+        },
+        "scale": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "mass",
+        "minRPM",
+        "maxRPM",
+        "driveRatio",
+        "engineInertia",
+        "startAltitude",
+        "minimumSpeed",
+        "parts",
+        "contactProperties",
+        "instruments",
+        "sounds",
+        "cameras",
+        "shadowBox"
+      ]
+    }
+  },
+  "items": {
+    "type": "object",
+    "allOf": [
+      {
+        "$ref": "#/definitions/Definition"
+      },
+      {
+        "$ref": "#/definitions/PluginsDefinitions"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Our types made it possible to create a JSON schema for aircraft definitions. The schema can be loaded into IDEs and provide helpful autocomplete and type annotations like the annotations typescript gives when writing objects.
The schema can even allow changing the editor on the GeoFS backend page into [monaco editor](https://github.com/microsoft/monaco-editor) using an extension, which will enable community contributors to more easily write their definitions straight on the backend site.